### PR TITLE
Fix web error "Cross-Origin Read Blocking "

### DIFF
--- a/backend/src/main/java/io/john/amiscaray/videosharingdemo/controllers/VideoController.java
+++ b/backend/src/main/java/io/john/amiscaray/videosharingdemo/controllers/VideoController.java
@@ -28,7 +28,7 @@ public class VideoController {
     }
 
     // {name} is a path variable in the url. It is extracted as the String parameter annotated with @PathVariable
-    @GetMapping("{name}")
+    @GetMapping(value = "{name}", produces = "video/mp4")
     public ResponseEntity<Resource> getVideoByName(@PathVariable("name") String name){
 
         return ResponseEntity


### PR DESCRIPTION
produces ="video/mp4" is now mandatory for reading in a browser a file sent in this way. Otherwise the file has the wrong header.